### PR TITLE
feat: add support for factory functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
 
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
 
@@ -63,7 +63,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
       - name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,6 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Set GOPATH and PATH
-        run: |
-          echo "::set-env name=GOPATH::$(dirname $GITHUB_WORKSPACE)"
-          echo "::add-path::$(dirname $GITHUB_WORKSPACE)/bin"
-        shell: bash
-
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,15 @@
+package inject
+
+import "reflect"
+
+var (
+	reflectTypeOfError = reflect.TypeOf((*error)(nil)).Elem()
+)
+
+func isStructPtr(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct
+}
+
+func implementsError(t reflect.Type) bool {
+	return t.Implements(reflectTypeOfError)
+}


### PR DESCRIPTION
The PR adds support for factory functions. From now, `inject` will allow registering a dependency by a factory function. The generated dependency will be injected like registering a pointer depdendency.